### PR TITLE
Moving CNL_USB_ERROR from a MessageItem.TYPE.ALERT_UPLOADER_ERROR to …

### DIFF
--- a/app/src/main/java/info/nightscout/android/history/PumpHistorySender.java
+++ b/app/src/main/java/info/nightscout/android/history/PumpHistorySender.java
@@ -64,7 +64,7 @@ public class PumpHistorySender {
                 .var(SENDEROPT.ALARM_PRIORITY, Integer.toString(MessageItem.PRIORITY.LOWEST.value()))
 
                 .opt(SENDEROPT.SYSTEM_PUMP_DEVICE_ERROR, dataStore.isNsEnableSystemStatus())
-                .opt(SENDEROPT.SYSTEM_CNL_USB_ERROR, dataStore.isnsEnableUploaderUsbError())
+                .opt(SENDEROPT.SYSTEM_CNL_USB_ERROR, dataStore.isNsEnableUploaderUsbError())
                 /*
                 makes lot of extra noise in NS when a user is in/out of range all day!
                 .opt(SENDEROPT.SYSTEM_PUMP_CONNECTTED, dataStore.isNsEnableSystemStatus())

--- a/app/src/main/java/info/nightscout/android/model/medtronicNg/PumpHistorySystem.java
+++ b/app/src/main/java/info/nightscout/android/model/medtronicNg/PumpHistorySystem.java
@@ -142,11 +142,11 @@ public class PumpHistorySystem extends RealmObject implements PumpHistoryInterfa
                 priority = MessageItem.PRIORITY.LOWEST;
                 title = "Debug";
                 break;
-            case CNL_USB_ERROR:
             case PUMP_DEVICE_ERROR:
                 type = MessageItem.TYPE.ALERT_UPLOADER_ERROR;
                 priority = MessageItem.PRIORITY.EMERGENCY;
                 break;
+            case CNL_USB_ERROR:
             case COMMS_PUMP_CONNECTED:
             case COMMS_PUMP_LOST:
             case COMMS_PUMP_LOW_BATTERY_MODE:

--- a/app/src/main/java/info/nightscout/android/model/store/DataStore.java
+++ b/app/src/main/java/info/nightscout/android/model/store/DataStore.java
@@ -905,7 +905,7 @@ public class DataStore extends RealmObject {
     public boolean isNsEnableUploaderBatteryFull() {
         return nsEnableSystemStatus && nsEnableUploaderBatteryFull;
     }
-    public boolean isnsEnableUploaderUsbError() {
+    public boolean isNsEnableUploaderUsbError() {
         return nsEnableSystemStatus && nsEnableUploaderUsbError;
     }
 


### PR DESCRIPTION
…MessageItem.TYPE.ALERT_UPLOADER_CONNECTION so that it did not cause PRIORITY.EMERGENCY errors in Pushover